### PR TITLE
- Recursor repository referenced instead of authoritative, EPEL packa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl -q -H 'X-API-Key: SOMEKEY' http://myserver.apnscp.com/api/v1/servers/localh
 
 Every server that runs apnscp may delegate DNS authority to PowerDNS. This is ideal in distributed infrastructures in which coordination allows for seamless [server-to-server migrations](<https://hq.apnscp.com/account-migration-guide/> ).
 
-Taking the **API key** from above, configure `/usr/local/apnscp/config/auth.yaml`. Configuration within this file is secret and is not exposed via apnscp's API.
+Taking the **API key** from above, configure `/usr/local/apnscp/config/auth.yaml`. Configuration within this file is secret and is not exposed via apnscp's API. Once set restart apnscp to compile configuration, `systemctl restart apnscp`.
 
 ```yaml
 pdns:
@@ -142,7 +142,7 @@ pdns:
 PowerDNS may be configured as the default provider for all sites using the `dns.default-provider` [Scope](https://gitlab.com/apisnetworks/apnscp/blob/master/docs/admin/Scopes.md). When adding a site in Nexus or [AddDomain](https://hq.apnscp.com/working-with-cli-helpers/#adddomain) the key will be replaced with "DEFAULT". This is substituted automatically on account creation.
 
 ```bash
-cpcmd config_set dns.default-provider powerdns
+cpcmd config:set dns.default-provider powerdns
 ```
 
 > Do not set dns.default-provider-key. API key is configured via `config/auth.yaml`.

--- a/plays/powerdns-authoritative-setup/tasks/main.yml
+++ b/plays/powerdns-authoritative-setup/tasks/main.yml
@@ -18,7 +18,7 @@
   yum:
     name: "{{ powerdns_packages }}"
     state: "{{ powerdns_enabled | ternary('present', 'absent') }}"
-
+    lock_timeout: 300
 - name: Setup PowerDNS
   include_tasks: setup-powerdns.yml
   when: powerdns_enabled | bool

--- a/plays/powerdns-authoritative-setup/templates/powerdns.repo.j2
+++ b/plays/powerdns-authoritative-setup/templates/powerdns.repo.j2
@@ -1,6 +1,6 @@
 [powerdns-rec-{{ powerdns_version | regex_replace('\.', '')}}]
-name=PowerDNS repository for PowerDNS Recursor - version {{ powerdns_version }}.X
-baseurl=http://repo.powerdns.com/centos/$basearch/$releasever/rec-{{ powerdns_version | regex_replace('\.', '')}}
+name=PowerDNS repository for PowerDNS - version {{ powerdns_version }}.X
+baseurl=http://repo.powerdns.com/centos/$basearch/$releasever/auth-{{ powerdns_version | regex_replace('\.', '')}}
 gpgkey=https://repo.powerdns.com/FD380FBB-pub.asc
 gpgcheck=1
 enabled=1
@@ -8,10 +8,10 @@ priority=90
 includepkg=pdns*
 
 [powerdns-rec-{{powerdns_version | regex_replace('\.', '')}}-debuginfo]
-name=PowerDNS repository for PowerDNS Recursor - version {{ powerdns_version }}.X debug symbols
-baseurl=http://repo.powerdns.com/centos/$basearch/$releasever/rec-{{ powerdns_version | regex_replace('\.', '')}}/debug
+name=PowerDNS repository for PowerDNS - version {{ powerdns_version }}.X debug symbols
+baseurl=http://repo.powerdns.com/centos/$basearch/$releasever/auth-{{ powerdns_version | regex_replace('\.', '')}}/debug
 gpgkey=https://repo.powerdns.com/FD380FBB-pub.asc
 gpgcheck=1
 enabled=0
-priority=90
+priority=10
 includepkg=pdns*

--- a/src/Api.php
+++ b/src/Api.php
@@ -36,7 +36,7 @@ class Api {
         $this->key      = AUTH_PDNS_KEY;
         $this->endpoint = AUTH_PDNS_URI;
         $this->client   = new \GuzzleHttp\Client([
-            'base_uri' => $this->endpoint,
+            'base_uri' => rtrim($this->endpoint, '/') . '/',
         ]);
     }
 
@@ -54,7 +54,7 @@ class Api {
             warn("Stripping `/' from endpoint `%s', remove the trailing / from auth.yaml", $endpoint);
             $endpoint = ltrim($endpoint, '/');
         }
-        if (strpos($endpoint, 'server') === false)
+        if (strpos($endpoint, 'servers') === false)
         {
             $endpoint = 'servers/localhost/' . $endpoint;
         }


### PR DESCRIPTION
…ges always pulled despite version

- Accept trailing "/" in pdns.uri
- strpos() looks for "server" instead of "servers" in determining whether to append "servers/localhost"
- handle ServerException faults in add_zone_backend
- renderMessage() supports ServerException and ClientException faults
- key/endpoint validation error messages

Signed-off-by: Matt Saladna <msaladna@apisnetworks.com>